### PR TITLE
Baseline grids

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 
+.DS_Store
 .bundle/
 .sass-cache/
 npm-debug.log

--- a/documentation/_components/grid.md
+++ b/documentation/_components/grid.md
@@ -1,0 +1,39 @@
+---
+layout: component
+type: layout
+title: Grid
+---
+
+### Containers
+
+<div class="container container--sm">I am a small container</div>
+
+<pre>
+  <code>
+    &lt;div class="container container--sm">I am a small container&lt;/div>
+  </code>
+</pre>
+
+<div class="container container--med">I am a medium container</div>
+
+<pre>
+  <code>
+    &lt;div class="container container--med">I am a medium container&lt;/div>
+  </code>
+</pre>
+
+<div class="container container--lg">I am a large container</div>
+
+<pre>
+  <code>
+    &lt;div class="container container--lg">I am a large container&lt;/div>
+  </code>
+</pre>
+
+<div class="container container--xl">I am an extra large container</div>
+
+<pre>
+  <code>
+    &lt;div class="container container--xl">I am an extra large container&lt;/div>
+  </code>
+</pre>

--- a/documentation/_includes/head.html
+++ b/documentation/_includes/head.html
@@ -11,8 +11,6 @@
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
   <link rel="shortcut icon" type="image/x-icon" href="{{ '/img/favicon.ico' | prepend: site.baseurl }}" />
 
-  <script async="true" src="/js/scpr-style.js"></script>
-
   <script src="https://use.typekit.net/cka2qre.js"></script>
   <script>try{Typekit.load({ async: true });}catch(e){}</script>
 </head>

--- a/documentation/_layouts/default.html
+++ b/documentation/_layouts/default.html
@@ -17,6 +17,8 @@
 
     {% include footer.html %}
 
+  <script async="true" src="/js/scpr-style.js"></script>
+  
   </body>
 
 </html>

--- a/documentation/css/main.scss
+++ b/documentation/css/main.scss
@@ -17,6 +17,7 @@
 pre {
   background: #F1F1F1;
   font-size: 0.75em;
+  margin: 3rem 0;
   max-width: 90%;
   overflow: scroll;
 }
@@ -147,4 +148,17 @@ pre {
 .section_container {
   background-color: #1F2C38;
   margin-top: 6rem
+}
+
+// OVERRIDES
+// These styles override source styling for components in order to better
+// document the styling and behavior of components.
+
+.container {
+  background-color: DodgerBlue;
+  color: white;
+
+  & > {
+    background-color: DeepSkyBlue;
+  }
 }

--- a/documentation/css/scpr-style.css
+++ b/documentation/css/scpr-style.css
@@ -154,6 +154,23 @@ svg path, svg g {
   fill: inherit;
   stroke: inherit; }
 
+.container {
+  box-sizing: border-box;
+  margin-left: auto;
+  margin-right: auto;
+  padding: 2rem 2rem; }
+  @media (max-width: 30rem) {
+    .container {
+      padding: 1rem 1rem; } }
+  .container--sm {
+    max-width: 44rem; }
+  .container--med {
+    max-width: 56rem; }
+  .container--lg {
+    max-width: 64rem; }
+  .container--xl {
+    max-width: 84rem; }
+
 .c-list--vert > * {
   display: block;
   margin-bottom: 1em; }
@@ -211,7 +228,7 @@ svg path, svg g {
 
 .media {
   display: block;
-  margin: 0 0 2rem; }
+  margin: 0; }
   .media::after {
     clear: both;
     content: '';
@@ -373,8 +390,8 @@ svg path, svg g {
 .media--hp-large {
   margin-top: 2rem; }
   .media--hp-large > .media__content {
-    box-shadow: inset 17em 0 0 #F6F6F6;
-    padding: 2rem 0 2rem 19em; }
+    box-shadow: inset 17rem 0 0 #F6F6F6;
+    padding: 2rem 0 4rem 19rem; }
   .media--hp-large > .media__figure {
     border-bottom: 6px solid #D15904;
     margin: 0 -2rem;
@@ -405,7 +422,8 @@ svg path, svg g {
   -webkit-box-pack: center;
   -webkit-justify-content: center;
       -ms-flex-pack: center;
-          justify-content: center; }
+          justify-content: center;
+  margin: 0 0 2rem; }
   .media--horizontalSmall .media__figure {
     margin-right: 1.125rem;
     max-width: 5rem; }

--- a/documentation/js/scpr-style.js
+++ b/documentation/js/scpr-style.js
@@ -1,41 +1,34 @@
 (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
 
-window.onload = function () {
+// Collect large headlines that might need resizing.
+var headlines = document.getElementsByClassName("media__headline--h1");
 
-  // Collect large headlines that might need resizing.
-  var headlines = document.getElementsByClassName("media__headline--h1");
-  console.log(headlines);
+function checkLengthAndResize(headline, index) {
 
-  function checkLengthAndResize(headline, index) {
+  // Look inside the headline's hyperlink to get the text
+  // character count.
+  var charCount = headline.getElementsByTagName("a")[0].textContent.length;
 
-    // Look inside the headline's hyperlink to get the text
-    // character count.
-    var charCount = headline.getElementsByTagName("a")[0].textContent.length;
-    console.log(charCount);
-
-    // If this is a headline likely to wrap to three lines,
-    // let's add a class to typeset it smaller.
-    if (charCount > 60) {
-      headline.classList.add("media__headline--h1-verbose");
-    }
+  // If this is a headline likely to wrap to three lines,
+  // let's add a class to typeset it smaller.
+  if (charCount > 60) {
+    headline.classList.add("media__headline--h1-verbose");
   }
+}
 
-  // Iterate through large headlines and resize where appropriate.
-  Array.from(headlines).forEach(checkLengthAndResize);
-};
+// Iterate through large headlines and resize where appropriate.
+Array.from(headlines).forEach(checkLengthAndResize);
 
 },{}],2:[function(require,module,exports){
 
-window.onload = function () {
-  var ajax = new XMLHttpRequest();
-  ajax.open("GET", "/img/scpr-sprite.svg", true);
-  ajax.send();
-  ajax.onload = function (e) {
-    var div = document.createElement("div");
-    div.style.display = "none";
-    div.innerHTML = ajax.responseText;
-    document.body.insertBefore(div, document.body.childNodes[0]);
-  };
+var ajax = new XMLHttpRequest();
+ajax.open("GET", "/img/scpr-sprite.svg", true);
+ajax.send();
+ajax.onload = function (e) {
+  var div = document.createElement("div");
+  div.style.display = "none";
+  div.innerHTML = ajax.responseText;
+  document.body.insertBefore(div, document.body.childNodes[0]);
 };
 
 },{}],3:[function(require,module,exports){

--- a/src/css/components/_media.scss
+++ b/src/css/components/_media.scss
@@ -22,7 +22,7 @@
 .media {
   @include clearfix();
   display: block;
-  margin: 0 0 $base-line-height;
+  margin: 0;
 
   &__figure {
     box-sizing: border-box;
@@ -277,8 +277,8 @@
   margin-top: $base-line-height;
 
   > .media__content {
-    box-shadow: inset 17em 0 0 $color-gray-lightest;
-    padding: $base-line-height 0 $base-line-height 19em;
+    box-shadow: inset 17rem 0 0 $color-gray-lightest;
+    padding: $base-line-height 0 ($base-line-height * 2) 19rem;
   }
 
   > .media__figure {
@@ -316,6 +316,7 @@
   align-items: center;
   display: flex;
   justify-content: center;
+  margin: 0 0 $base-line-height;
 
   .media__figure {
     margin-right: 1.125rem;

--- a/src/css/layout/_containers.scss
+++ b/src/css/layout/_containers.scss
@@ -1,0 +1,37 @@
+
+// Containers: Horizontal blocks that hold content or grid elements.
+// Size modifiers are used to achieve containers of different widths.
+//
+// .container--sm         - 640px max-width; good for article body
+// .container--med        - 832px max-width
+// .container--lg         - 960px max-width
+// .container--xl         - 1280px max-width
+//
+// Styleguide 0.1.0
+
+.container {
+  box-sizing: border-box;
+  margin-left: auto;
+  margin-right: auto;
+  padding: $base-line-height $gutter;
+
+  @include media-max($media-mobile) {
+    padding: ($base-line-height / 2) ($gutter / 2);
+  }
+
+  &--sm {
+    @include container-width(20);
+  }
+
+  &--med {
+    @include container-width(26);
+  }
+
+  &--lg {
+    @include container-width(30);
+  }
+
+  &--xl {
+    @include container-width(40);
+  }
+}

--- a/src/css/layout/_grids.scss
+++ b/src/css/layout/_grids.scss
@@ -1,0 +1,5 @@
+
+// Grids: Classes for creating layouts.
+//
+//
+// Styleguide 0.1.0

--- a/src/css/layout/all.scss
+++ b/src/css/layout/all.scss
@@ -1,3 +1,3 @@
 
-@import "containers";
-@import "grids";
+@import 'containers';
+@import 'grids';

--- a/src/css/layout/all.scss
+++ b/src/css/layout/all.scss
@@ -1,0 +1,3 @@
+
+@import "containers";
+@import "grids";

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -1,5 +1,5 @@
 
-@import "util/all.scss";
-@import "base/all.scss";
-@import "layout/all.scss";
-@import "components/all.scss";
+@import 'util/all';
+@import 'base/all';
+@import 'layout/all';
+@import 'components/all';

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -1,4 +1,5 @@
 
 @import "util/all.scss";
 @import "base/all.scss";
+@import "layout/all.scss";
 @import "components/all.scss";

--- a/src/css/util/_mixins.scss
+++ b/src/css/util/_mixins.scss
@@ -10,12 +10,42 @@
 }
 
 // UNDERLINES
-
 // Sweet, sexy underlines for hyperlinks
+
 @mixin link-underline($underline-color) {
   background: linear-gradient(#fff, #fff), linear-gradient(#fff, #fff), linear-gradient($underline-color, $underline-color);
   background-position: 0 90%, 100% 90%, 0 90%;
   background-repeat: no-repeat, no-repeat, repeat-x;
   background-size: .05em 1px, .05em 1px, 1px 1px;
   text-shadow: .03em 0 #fff, -.03em 0 #fff, 0 .03em #fff, 0 -.03em #fff, .06em 0 #fff, -.06em 0 #fff, .09em 0 #fff, -.09em 0 #fff, .12em 0 #fff, -.12em 0 #fff,.15em 0 #fff,-.15em 0 #fff;
+}
+
+
+// CONTAINER WIDTHS
+// Calculate max-widths for grid containers.
+
+@mixin container-width($rems) {
+
+  // Calculate max-width using gutter as an important number,
+  // and adding two extra gutters equal to the standard
+  // padding given to containers.
+  $max-container-width: ($rems * $gutter) + ($gutter * 2);
+
+  max-width: $max-container-width;
+}
+
+// MEDIA QUERIES
+
+// Min-width media queries
+@mixin media-min($query) {
+  @media ('min-width:' + $query) {
+    @content;
+  }
+}
+
+// Max-width media queries
+@mixin media-max($query) {
+  @media ('max-width:' + $query) {
+    @content;
+  }
 }

--- a/src/css/util/_vars.scss
+++ b/src/css/util/_vars.scss
@@ -42,8 +42,21 @@ $font-size-default: 1.125rem;
 $base-line-height: 2rem;
 
 
-// MODULAR SCALE
+// MODULAR TYPE SCALE
 // set overrides for Modular Scale (docs at https://github.com/modularscale/modularscale-sass)
 
 $ms-base: $font-size-default;
 $ms-ratio: 1.2;
+
+
+// LAYOUT UNITS
+
+$gutter: $base-line-height;
+
+
+// MEDIA QUERIES
+
+$media-mobile: 30rem;
+$media-tablet: 56rem;
+$media-desktop: 64rem;
+$media-wide: 84rem;

--- a/src/js/fitText.js
+++ b/src/js/fitText.js
@@ -3,15 +3,12 @@ window.onload = function() {
 
   // Collect large headlines that might need resizing.
   var headlines = document.getElementsByClassName("media__headline--h1");
-  console.log(headlines);
-
 
   function checkLengthAndResize(headline, index) {
 
     // Look inside the headline's hyperlink to get the text
     // character count.
     var charCount = headline.getElementsByTagName("a")[0].textContent.length;
-    console.log(charCount);
 
     // If this is a headline likely to wrap to three lines,
     // let's add a class to typeset it smaller.

--- a/src/js/fitText.js
+++ b/src/js/fitText.js
@@ -1,6 +1,4 @@
 
-window.onload = function() {
-
   // Collect large headlines that might need resizing.
   var headlines = document.getElementsByClassName("media__headline--h1");
 
@@ -19,4 +17,3 @@ window.onload = function() {
 
   // Iterate through large headlines and resize where appropriate.
   Array.from(headlines).forEach(checkLengthAndResize);
-}

--- a/src/js/loadSvg.js
+++ b/src/js/loadSvg.js
@@ -1,5 +1,4 @@
 
-window.onload = function() {
   var ajax = new XMLHttpRequest();
   ajax.open("GET", "/img/scpr-sprite.svg", true);
   ajax.send();
@@ -9,4 +8,3 @@ window.onload = function() {
     div.innerHTML = ajax.responseText;
     document.body.insertBefore(div, document.body.childNodes[0]);
   }
-}


### PR DESCRIPTION
- Adds vars and mixins for media query and layout needs
- Adds layout dir to `/src/css` to store SCSS for grids, containers and other layout needs
- first pass at containers SCSS

### Incidental

- update .gitignore
- improve margins and padding on media objects
- remove window.onload from JS modules, move JS call to closing </body> tag
- remove console logging from JS modules